### PR TITLE
Update migration_guide.md

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -26,6 +26,7 @@ dependencies:
   #flutter:
   #  sdk: flutter
   flutter_web: any
+  flutter_web_ui: any
 
 dev_dependencies:
   ## REPLACE


### PR DESCRIPTION
`flutter_web_ui` is obviously essential to make this API run properly.  With the current migration guide, it is not included in the dependencies; I suspect this was just a mistake.  I noticed the mistake in a live stream earlier today.   I've updated the included `pubspec.yaml` file to correct this. 