### PR TITLE
fixed migration_guide dependency_overrides

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -66,6 +66,10 @@ dependency_overrides:
     git:
       url: https://github.com/flutter/flutter_web
       path: packages/flutter_web_ui
+  flutter_web_test:
+    git:
+      url: https://github.com/flutter/flutter_web
+      path: packages/flutter_web_test
 ```
 
 # `lib/`


### PR DESCRIPTION
```console
flutter_web_test any which doesn't exist (could not find package flutter_web_test at https://pub.dartlang.org)
```

added flutter_web_test to dependency overrides.