### PR TITLE
Update migration guide documentation dev dependency versions

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -36,8 +36,8 @@ dev_dependencies:
 
   ## ADD
   ## Add these dependencies to enable the Dart web build system
-  build_runner: ^1.2.2
-  build_web_compilers: ^1.1.0
+  build_runner: ^1.4.0
+  build_web_compilers: ^2.0.0
 
   test: ^1.3.4
 


### PR DESCRIPTION
Update the migration dev dependencies to the same versions as the example apps provided. This fixes build error https://github.com/flutter/flutter/issues/35526 encountered when using old versions while following the migration guide. 