### PR TITLE
PlatformView: recreate surface if the controller changes

### DIFF
--- a/packages/flutter_web/lib/src/widgets/platform_view.dart
+++ b/packages/flutter_web/lib/src/widgets/platform_view.dart
@@ -846,6 +846,9 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
 
     if (widget.viewType != oldWidget.viewType) {
       _controller?.dispose();
+      // the _surface has to be recreated as its controller is disposed
+      // setting _surface to null will trigger its creation in build()
+      _surface = null;
 
       // We are about to create a new platform view.
       _platformViewCreated = false;


### PR DESCRIPTION
Currently the surface of a platform view is only created only one when the state of PlatformViewLink is created. When the PlatformViewLink widget changes, the PlatformViewController in the corresponding state ist also updated. Just the surface is not updated even though it depends  on the controller.

This PR changes this behaviour to recreate the surface whenever the controller ist updated.