### PR TITLE
added dispose handler for calls to flutter/platform_view

### DIFF
--- a/packages/flutter_web_ui/lib/src/engine/platform_views.dart
+++ b/packages/flutter_web_ui/lib/src/engine/platform_views.dart
@@ -50,6 +50,9 @@ void handlePlatformViewCall(
     case 'create':
       _createPlatformView(decoded, callback);
       return;
+    case 'dispose':
+      _disposePlatformView(decoded, callback);
+      return;
   }
   callback(null);
 }
@@ -74,5 +77,17 @@ void _createPlatformView(
       platformViewRegistry._registeredFactories[viewType](id);
 
   platformViewRegistry._createdViews[id] = element;
+  callback(codec.encodeSuccessEnvelope(null));
+}
+
+void _disposePlatformView(
+    MethodCall methodCall, ui.PlatformMessageResponseCallback callback) {
+  final int id = methodCall.arguments;
+  const MethodCodec codec = StandardMethodCodec();
+
+  // remove the root element of the view from the DOM
+  platformViewRegistry._createdViews[id]?.remove();
+  platformViewRegistry._createdViews.remove(id);
+
   callback(codec.encodeSuccessEnvelope(null));
 }


### PR DESCRIPTION
This PR adds the missing handler for the 'dispose' MethodCall to the PlatformViewChannel ( flutter/platform_view ). This MethodCall is already invoked by _HtmlElementViewController in https://github.com/flutter/flutter_web/blob/3973ac51f326c0a013232f39e9962bd02712d7dd/packages/flutter_web/lib/src/widgets/platform_view.dart#L412 and yields a MissingPluginException Error without the corresponding implementation. 